### PR TITLE
Fixed a crash and a change to remove compiler warning

### DIFF
--- a/listpack-test.c
+++ b/listpack-test.c
@@ -26,10 +26,16 @@ void dumpListpack(unsigned char *lp) {
 
 #define LP_SELF_TEST_MAX_ELE (1024*5) /* Make sure to stress 32 bit strings. */
 unsigned long lpSelfTestRandomElement(unsigned char *ele) {
+    long long half_max = LLONG_MAX / 2;
     if (rand() % 2) {
         long long max = 16, n;
-        while((rand() % 6) != 0) max *= 2;
-        if (max <= 0) max = LLONG_MAX;
+        while((rand() % 6) != 0) {
+            if (max > half_max) {
+                max = LLONG_MAX;
+                break;
+            }
+            max *= 2;
+        }
         n = rand() % max;
         if (rand() % 2) n = -n;
         return snprintf((char*)ele,LP_SELF_TEST_MAX_ELE,"%lld",n);

--- a/listpack.c
+++ b/listpack.c
@@ -560,7 +560,7 @@ unsigned char *lpGet(unsigned char *p, int64_t *count, unsigned char *intbuf) {
     /* Return the string representation of the integer or the value itself
      * depending on intbuf being NULL or not. */
     if (intbuf) {
-        *count = snprintf((char*)intbuf,LP_INTBUF_SIZE,"%lld",val);
+        *count = snprintf((char*)intbuf,LP_INTBUF_SIZE,"%ld",val);
         return intbuf;
     } else {
         *count = val;


### PR DESCRIPTION
GCC 11.4.0 seems to optimize away the below line in in listpack-test.c (lnumber 32, function lpSelfTestRandomElement ):
        if (max <= 0) max = LLONG_MAX;        
And that is causing the test to crash sometime. 
Removing -O2 compiler flag from the Makefile,  or disabling optimization for the function lpSelfTestRandomElement will also fix the issue. 
But, it seems modifying the code will be the better option. 
     